### PR TITLE
Add olist libs import section

### DIFF
--- a/flake8_import_order/__about__.py
+++ b/flake8_import_order/__about__.py
@@ -12,7 +12,7 @@ __summary__ = (
 )
 __uri__ = "https://github.com/PyCQA/flake8-import-order"
 
-__version__ = "0.16"
+__version__ = "0.17"
 
 __author__ = "Alex Stapleton"
 __email__ = "alexs@prol.etari.at"

--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -5,6 +5,7 @@ from flake8_import_order.__about__ import (
     __author__, __copyright__, __email__, __license__, __summary__, __title__,
     __uri__, __version__,
 )
+from flake8_import_order.olistlib_list import OLISTLIB_NAMES
 from flake8_import_order.stdlib_list import STDLIB_NAMES
 
 __all__ = [
@@ -17,6 +18,7 @@ DEFAULT_IMPORT_ORDER_STYLE = 'cryptography'
 IMPORT_FUTURE = 0
 IMPORT_STDLIB = 10
 IMPORT_3RD_PARTY = 20
+IMPORT_OLISTLIB = 24
 IMPORT_APP_PACKAGE = 30
 IMPORT_APP = 40
 IMPORT_APP_RELATIVE = 50
@@ -110,6 +112,8 @@ class ImportVisitor(ast.NodeVisitor):
                 return IMPORT_APP_PACKAGE
             elif package in STDLIB_NAMES:
                 return IMPORT_STDLIB
+            elif package in OLISTLIB_NAMES:
+                return IMPORT_OLISTLIB
 
         # Not future, stdlib or an application import.
         # Must be 3rd party.

--- a/flake8_import_order/olistlib_list.py
+++ b/flake8_import_order/olistlib_list.py
@@ -1,0 +1,9 @@
+OLISTLIB_NAMES = (
+    "b2w_sac_client",
+    "branded_store_utils",
+    "olist_aws",
+    "olist_b2w",
+    "olist_clients",
+    "olist_commons",
+    "olist_django",
+)

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -4,7 +4,7 @@ import pycodestyle
 
 import pytest
 
-from flake8_import_order import STDLIB_NAMES
+from flake8_import_order import OLISTLIB_NAMES, STDLIB_NAMES
 from flake8_import_order.checker import ImportOrderChecker
 
 
@@ -27,6 +27,14 @@ def _checker(data):
 @pytest.mark.parametrize('import_name', _load_test_cases())
 def test_styles(import_name):
     data = "import {}\nimport zlib\n".format(import_name)
+    checker = _checker(data)
+    codes = [error.code for error in checker.check_order()]
+    assert codes == []
+
+
+@pytest.mark.parametrize('import_name', OLISTLIB_NAMES)
+def test_olist_lib(import_name):
+    data = "import ast\n\nimport django\n\nimport {}".format(import_name)
     checker = _checker(data)
     codes = [error.code for error in checker.check_order()]
     assert codes == []


### PR DESCRIPTION
In order to follow OEP8 [1] import guidelines it's necessary to create an import section for olist libs. This PR does that.

I may have missed some internal libs from the list.

Example:

```python
# stdlib section
import ast
import itertools

# 3rd-party section
import django

# olist libs section - this PR adds this
import olist_clients
import olist_django

# local imports
from . import ponto
```

[1] https://jira-olist.atlassian.net/wiki/spaces/OP/pages/52461580/0008+-+Diretrizes+de+Estilo+de+C+digo+Python#id-0008-DiretrizesdeEstilodeC%C3%B3digoPython-Imports